### PR TITLE
Generate tag names for AWS ECR

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,14 +1,6 @@
 name: 'Docker image tag'
 description: 'Generate docker image'
-inputs:
-  docker-registry-base-name:
-    description: 'Base name of docker registry'
-    required: true
 outputs:
-  docker-image-branch: # id of output
-    description: 'Docker image name with branch'
-  docker-image-branch-sha:
-    description: 'Docker image name with branch and short sha'
   docker-sanitized-branch-name:
     description: 'Sanitized branch name for use as docker tag'
   docker-sanitized-branch-name-sha:

--- a/action.yml
+++ b/action.yml
@@ -9,6 +9,10 @@ outputs:
     description: 'Docker image name with branch'
   docker-image-branch-sha:
     description: 'Docker image name with branch and short sha'
+  docker-sanitized-branch-name:
+    description: 'Sanitized branch name for use as docker tag'
+  docker-sanitized-branch-name-sha:
+    description: 'Sanitized branch name with short sha for use as docker tag'
 runs:
   using: 'node12'
   main: 'index.js'

--- a/index.js
+++ b/index.js
@@ -5,10 +5,14 @@ try {
   const repoName = process.env["GITHUB_REPOSITORY"].split('/')[1];
   const shortSha = process.env["GITHUB_SHA"].slice(0, 8);
   const sanitizedBranchName = process.env["GITHUB_REF"].split("refs/heads/")[1].replace("/", "-");
+  // TODO: this follows a convention from Google Cloud. Needs to be refactored in future
   const dockerImageName = `${registryBase}/${repoName}`;
 
   core.setOutput("docker-image-branch", `${dockerImageName}:${sanitizedBranchName}`);
   core.setOutput("docker-image-branch-sha", `${dockerImageName}:${sanitizedBranchName}-${shortSha}`);
+  core.setOutput("docker-sanitized-branch-name", sanitizedBranchName);
+  core.setOutput("docker-sanitized-branch-name-sha", `${sanitizedBranchName}-${shortSha}`);
+
 } catch (error) {
   core.setFailed(error.message);
 }

--- a/index.js
+++ b/index.js
@@ -1,15 +1,9 @@
 const core = require("@actions/core");
 
 try {
-  const registryBase = core.getInput("docker-registry-base-name");
-  const repoName = process.env["GITHUB_REPOSITORY"].split('/')[1];
   const shortSha = process.env["GITHUB_SHA"].slice(0, 8);
   const sanitizedBranchName = process.env["GITHUB_REF"].split("refs/heads/")[1].replace("/", "-");
-  // TODO: this follows a convention from Google Cloud. Needs to be refactored in future
-  const dockerImageName = `${registryBase}/${repoName}`;
 
-  core.setOutput("docker-image-branch", `${dockerImageName}:${sanitizedBranchName}`);
-  core.setOutput("docker-image-branch-sha", `${dockerImageName}:${sanitizedBranchName}-${shortSha}`);
   core.setOutput("docker-sanitized-branch-name", sanitizedBranchName);
   core.setOutput("docker-sanitized-branch-name-sha", `${sanitizedBranchName}-${shortSha}`);
 


### PR DESCRIPTION
- Simplify the code
- Remove Google Cloud specific functionality
- Provide sanitized names for branch and branch+short_sha to use as docker tags